### PR TITLE
Fix handling Datetime error for PHP 8.2+

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -149,7 +149,10 @@ class Converter
             $errors = DateTime::getLastErrors();
         }
 
-        if ($errors['warning_count'] == 0 && $errors['error_count'] == 0 && $date) {
+        if (($errors === false
+            || ($errors['warning_count'] == 0 && $errors['error_count'] == 0))
+            && $date
+        ) {
             $date->setTimeZone($this->timezone);
             return $date;
         }


### PR DESCRIPTION
Datetime:getLastErrors from PHP version 8.2 return false if there were no errors or warnings.

https://github.com/php/php-src/issues/9431